### PR TITLE
12519: remove facilities and capital planning docs and replace with github links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # Welcome to DCP Capital Planning Docs
 
-This is where we share documentation for our data products.
+This is where we share documentation for our data products. You can access these docs on our <a href="https://github.com/NYCPlanning/db-facilities/wiki" target="_blank">Facilities Database github</a>, our <a href="https://github.com/NYCPlanning/db-cpdb/wiki" target="_blank">Capital Projects Database github</a>, and our <a href="https://github.com/NYCPlanning/db-cpdb/wiki" target="_blank">Developments Database github</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,6 @@
 site_name: Capital Planning Docs
 pages:
 - Home: index.md
-- Facilities Database: facdb.md
-- Capital Projects Database: cpdb.md
 # - Residential Pipeline: pipeline.md
 theme: readthedocs
 theme_dir: custom_theme


### PR DESCRIPTION
This PR removes the extra pages that display the docs for Facilities and Capital Projects. Instead we now just include github links on the docs Home page. The developments database github link was also added to this docs page. 

Open to language change suggestions! 

Closes #AB12519

![new_cp_docs](https://user-images.githubusercontent.com/26672885/95104918-6cb50b80-0704-11eb-8adb-75a01ac0a1f5.png)
